### PR TITLE
change name of fabric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.pyt
 *.pytc
 *.egg
+*.egg-info
 .DS_Store
 .*.swp
 Fabric.egg-info

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ install_requires += [
 ]
 
 setup(
-    name='Fabric',
+    name='k-state-fabric-3',
     # version=get_version('short'),
-    version='1.10.2-0.2',
+    version='1.10.2.post2',
     description='Fabric is a simple, Pythonic tool for remote execution and deployment.',
     long_description=long_description,
     author='Jeff Forcier',


### PR DESCRIPTION
### RMM

#### What's this PR do?
localshop is aware of other projects in the official repo. It will not allow uploading things that it thinks already exists. So, I changed the name 'fabric -> k-state-fabric-3'. Also changed the version scheme because pip didn't like it. As before VERSION is the upstream and N is our version in VERSION.postN.