### PR TITLE
Make bad text in terminal more robust

### DIFF
--- a/fabric/io.py
+++ b/fabric/io.py
@@ -73,13 +73,14 @@ class OutputLooper(object):
         self.write_buffer = RingBuffer([], maxlen=len(self.prefix))
 
     def _flush(self, text):
-        self.stream.write(text)
+        correct_text = text.encode(self.stream.encoding, errors='ignore')
+        self.stream.write(correct_text)
         # Actually only flush if not in linewise mode.
         # When linewise is set (e.g. in parallel mode) flushing makes
         # doubling-up of line prefixes, and other mixed output, more likely.
         if not env.linewise:
             self.stream.flush()
-        self.write_buffer.extend(text)
+        self.write_buffer.extend(correct_text)
 
     def loop(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ install_requires += [
 setup(
     name='k-state-fabric-3',
     # version=get_version('short'),
-    version='1.10.2.post7',
+    version='1.10.2.post8',
     description='Fabric is a simple, Pythonic tool for remote execution and deployment.',
     long_description=long_description,
     author='Jeff Forcier',


### PR DESCRIPTION
### RMM

#### What's this PR do?
Just ignore unicode errors.

#### Background
Apparently not everyones locale is set the same. It is my understanding that encoding should be propagated through sshlv s.

This should be fixed in vagrant, but this should patch the problem by simply ignoring errors that pop up.

#### Tickets
https://k-state.atlassian.net/browse/WEBCOMMON-15